### PR TITLE
Add references block macro for Markdown output

### DIFF
--- a/src/cff2pages/templates/md/base.md
+++ b/src/cff2pages/templates/md/base.md
@@ -1,5 +1,6 @@
 {%- from 'md/authors_macro.md' import authors_block -%}
 {%- from 'md/identifiers_macro.md' import identifier_block -%}
+{%- from 'md/reference_macro.md' import references_block -%}
 # {{ title }}
 
 {{ authors_block(authors, unique_affiliations) -}}
@@ -11,7 +12,4 @@
 - Keyword 2
 - Keyword 3
 
-## References
-
-- Reference 1
-- Reference 2
+{{ references_block(references) }}

--- a/src/cff2pages/templates/md/reference_macro.md
+++ b/src/cff2pages/templates/md/reference_macro.md
@@ -1,0 +1,8 @@
+{%- macro references_block(references) -%}
+{%- if references is defined %}
+## References
+
+{% for reference in references %}
+* {% if reference.type == 'article' %}📖{% elif reference.type == 'software' %}💻{%- endif %} {{ reference.title }}, {% for author in reference['authors'] %}{{+ author['given-names'] }} {{ author['family-names'] -}} {%- if author.orcid is defined -%} [![Author ORCID](./assets/img/orcid_16x16.webp)]({{ author.orcid }}){style="margin:3px"}{%- endif %}{%- if not loop.last %}, {% endif %}{%- endfor %}{% if reference.year %} {{- reference.year -}}{% endif %} [{{- reference.doi -}}](https://doi.org/{{ reference.doi }}){% endfor %}
+{%- endif %}
+{% endmacro %}


### PR DESCRIPTION
I do not like how almost all the templating is squished onto a single line. But it does seem to work...

![Screenshot 2024-11-20 at 15 00 04](https://github.com/user-attachments/assets/aa5531aa-575a-45da-a379-7c5ae1e6dd3a)
