### PR TITLE
use h2 for keywords heading in MD output

### DIFF
--- a/src/cff2pages/templates/md/keyword_macro.md
+++ b/src/cff2pages/templates/md/keyword_macro.md
@@ -16,7 +16,7 @@ Dependencies:
 #}
 {% macro keyword_block(keywords) %}
     {%- if keywords is defined -%}
-# Keywords
+## Keywords
 
         {%- for keyword in keywords %}
 - {{ keyword }}


### PR DESCRIPTION
The macro currently inserts "Keywords" as a top level (h1) heading, and it is good practice in web accessibility to include only one h1 heading per page. This PR bumps the keywords section heading down to h2.