### PR TITLE
Add support for codemeta.json metadata files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,33 @@ The Citation.cff is a fantastic format that combines human-readable and machine-
 about its repository. It provides linking systems with important metadata about the
 presented project and gives people the ability to reference the project, among other things.
 However, for a wide range of users, the YAML file format can seem intimidating, whereas a clean
-website is generally more readable. This project aims to automate the conversion of cff files,
-so that maintaining the cff file pays off for developers in terms of the project's presentation,
-thereby ensuring that the website representation is retained.
+website is generally more readable. This project aims to automate the conversion of cff or codemeta files, so that maintaining the cff file pays off for developers in terms of the project's presentation, thereby ensuring that the website representation is retained.
 
 ## Project Description
 
 cff2pages is envisioned as a Python package, designed to automate the extraction of metadata from
-your project's Citation.cff file, and swiftly generate a sleek, static HTML page. This versatile
-page can serve as a vivid representation of your project on Github/Gitlab Pages.
+your project's Citation.cff or Codemeta.json metadata files and swiftly generate a sleek, static HTML page. This versatile page can serve as a vivid representation of your project on Github/Gitlab Pages.
+
+## Supported Metadata Formats
+
+cff2pages currently supports the following metadata formats:
+
+- **Citation File Format (CFF)** – `CITATION.cff`
+- **CodeMeta** – `codemeta.json`
+
+If both files exist in a repository, you can explicitly select one using the `-i` option.
 
 ## Usage
 
 ```
 usage: cff2pages [-h] [-i [INPUT]] [-o [OUTPUT]]
 
-Converts citation information in Citation File Format into HTML or Markdown
+Converts citation information in Citation or Codemeta File Format into HTML or Markdown
 
 options:
   -h, --help            show this help message and exit
   -i [INPUT], --input [INPUT]
-                        path to the input CFF file. Default: ./CITATION.cff
+                        path to the input CFF file. Default: ./CITATION.cff ./codemeta.json
   -o [OUTPUT], --output [OUTPUT]
                         path to the output file. Default: public/citation.html
   -cb, --no-citation-box

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,147 @@
+{
+  "cff-version": "1.2.0",
+  "type": "software",
+  "title": "cff2pages: Generate Markup from Your codemeta.json File",
+  "version": "0.2.1",
+  "message": "If you use this software, please cite it using the metadata from this file.",
+  "abstract": "This repository generates HTML pages or Markdown sites for GitHub and GitLab based on your codemeta.json file. This ensures that your codemeta is optimized for both machine processing and human readability.",
+  "license": "MIT",
+  "repository-code": "https://github.com/University-of-Potsdam-MM/cff2pages",
+  "keywords": [
+    "cff",
+    "documentation",
+    "pages"
+  ],
+  "authors": [
+    {
+      "given-names": "Jan",
+      "family-names": "Bernoth",
+      "email": "jan.bernoth@uni-potsdam.de",
+      "affiliation": "University of Potsdam",
+      "orcid": "https://orcid.org/0000-0002-4127-0053"
+    },
+    {
+      "given-names": "Toby",
+      "family-names": "Hodges",
+      "affiliation": "The Carpentries",
+      "orcid": "https://orcid.org/0000-0003-1766-456X"
+    }
+  ],
+  "identifiers": [
+    {
+      "type": "swh",
+      "value": "swh:1:dir:1e3e28077c43ca999f434f29b6a872f5581b48e2",
+      "description": "The archive of this project in Software Heritage. All persistent versions are accessible via this directory"
+    },
+    {
+      "type": "doi",
+      "value": "10.5281/zenodo.8213986",
+      "description": "Zenodo DOI to the repository"
+    }
+  ],
+  "references": [
+    {
+      "type": "conference-paper",
+      "title": "cff2pages: Generate Markup from Your Citation.cff File",
+      "doi": "10.5281/zenodo.15638585",
+      "year": "2025",
+      "authors": [
+        {
+          "given-names": "Jan",
+          "family-names": "Bernoth",
+          "orcid": "https://orcid.org/0000-0002-4127-0053"
+        },
+        {
+          "given-names": "Toby",
+          "family-names": "Hodges",
+          "orcid": "https://orcid.org/0000-0003-1766-456X"
+        }
+      ]
+    },
+    {
+      "type": "conference-paper",
+      "title": "cff2pages: Generate a frontend from your metadata",
+      "doi": "10.5281/zenodo.10726204",
+      "year": "2024",
+      "authors": [
+        {
+          "given-names": "Jan",
+          "family-names": "Bernoth",
+          "orcid": "https://orcid.org/0000-0002-4127-0053"
+        }
+      ]
+    },
+    {
+      "type": "software",
+      "title": "Citation File Format",
+      "version": "1.2.0",
+      "doi": "10.5281/zenodo.1003149",
+      "authors": [
+        {
+          "family-names": "Druskat",
+          "given-names": "Stephan",
+          "orcid": "https://orcid.org/0000-0003-4925-7248"
+        },
+        {
+          "family-names": "Spaaks",
+          "given-names": "Jurriaan H.",
+          "orcid": "https://orcid.org/0000-0002-7064-4069"
+        },
+        {
+          "family-names": "Chue Hong",
+          "given-names": "Neil",
+          "orcid": "https://orcid.org/0000-0002-8876-7606"
+        },
+        {
+          "family-names": "Haines",
+          "given-names": "Robert",
+          "orcid": "https://orcid.org/0000-0002-9538-7919"
+        },
+        {
+          "family-names": "Baker",
+          "given-names": "James",
+          "orcid": "https://orcid.org/0000-0002-2682-6922"
+        },
+        {
+          "family-names": "Bliven",
+          "given-names": "Spencer",
+          "orcid: https": "//orcid.org/0000-0002-1200-1698",
+          "email": "spencer.bliven@gmail.com"
+        },
+        {
+          "family-names": "Willighagen",
+          "given-names": "Egon",
+          "orcid": "https://orcid.org/0000-0001-7542-0286"
+        },
+        {
+          "family-names": "Pérez-Suárez",
+          "given-names": "David",
+          "orcid": "https://orcid.org/0000-0003-0784-6909",
+          "website": "https://dpshelio.github.io"
+        },
+        {
+          "family-names": "Konovalov",
+          "given-names": "Olexandr",
+          "orcid": "https://orcid.org/0000-0001-5299-3292"
+        }
+      ]
+    },
+    {
+      "type": "article",
+      "title": "Ya2RO: A tool for creating Research Object from minimum metadata",
+      "doi": "10.4126/FRL01-006444984",
+      "year": "2023",
+      "authors": [
+        {
+          "given-names": "Antonia",
+          "family-names": "Pavel"
+        },
+        {
+          "given-names": "Daniel",
+          "family-names": "Garijo",
+          "orcid": "https://orcid.org/0000-0003-0454-7145"
+        }
+      ]
+    }
+  ]
+}

--- a/src/cff2pages/cff2pages.py
+++ b/src/cff2pages/cff2pages.py
@@ -3,6 +3,7 @@ import logging
 import shutil
 from argparse import ArgumentParser
 from pathlib import Path
+import json
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 from cffconvert.cli.create_citation import create_citation
@@ -115,16 +116,34 @@ def main_procedure(cff_path, init_path, show_citation_box=True):
         cff_file = 'CITATION.cff'
     else:
         cff_file = cff_path
-    citation = create_citation(cff_file, None)
-    citation.validate()
-    citation.cffobj['unique_affiliations'] = get_unique_affiliations((citation.cffobj['authors']))
-    if 'repository-code' in citation.cffobj:
-        citation.cffobj['repository'] = citation.cffobj['repository-code']
+
+    if cff_file.endswith('.json'):
+        with open(cff_file, 'r', encoding='utf-8') as f:
+            codemeta = json.load(f)
+
+        citation_data = {
+            "title": codemeta.get("name"),
+            "abstract": codemeta.get("description"),
+            "version": codemeta.get("version"),
+            "repository": codemeta.get("codeRepository"),
+            "date_released": codemeta.get("datePublished"),
+            "authors": codemeta.get("author", [])
+        }
+
+        index_html = template.render(citation_data, show_citation_box=show_citation_box)
+
     else:
-        logger.warning("Warning: No 'repository-code' found in CITATION.cff.")
-    citation.cffobj['citation'] = {}
-    citation.cffobj['citation']['apa'] = str(citation.as_apalike())
-    index_html = template.render(citation.cffobj, show_citation_box=show_citation_box)
+        citation = create_citation(cff_file, None)
+        citation.validate()
+        citation.cffobj['unique_affiliations'] = get_unique_affiliations((citation.cffobj['authors']))
+        if 'repository-code' in citation.cffobj:
+            citation.cffobj['repository'] = citation.cffobj['repository-code']
+        else:
+            logger.warning("Warning: No 'repository-code' found in CITATION.cff.")
+        citation.cffobj['citation'] = {}
+        citation.cffobj['citation']['apa'] = str(citation.as_apalike())
+        index_html = template.render(citation.cffobj, show_citation_box=show_citation_box)
+
     write_to_pub_folder(init_path, index_html)
 
 

--- a/src/cff2pages/cff2pages.py
+++ b/src/cff2pages/cff2pages.py
@@ -117,17 +117,27 @@ def main_procedure(cff_path, init_path, show_citation_box=True):
     else:
         cff_file = cff_path
 
+
     if cff_file.endswith('.json'):
         with open(cff_file, 'r', encoding='utf-8') as f:
             codemeta = json.load(f)
 
+        authors = []
+        for a in codemeta.get("author", []):
+            authors.append({
+                "given-names": a.get("givenName"),
+                "family-names": a.get("familyName"),
+                "email": a.get("email")
+            })
+
         citation_data = {
             "title": codemeta.get("name"),
-            "abstract": codemeta.get("description"),
+            "description": codemeta.get("description"),
             "version": codemeta.get("version"),
             "repository": codemeta.get("codeRepository"),
-            "date_released": codemeta.get("datePublished"),
-            "authors": codemeta.get("author", [])
+            "date-released": codemeta.get("datePublished"),
+            "authors": authors,
+            "citation": {}
         }
 
         index_html = template.render(citation_data, show_citation_box=show_citation_box)

--- a/src/cff2pages/cff2pages.py
+++ b/src/cff2pages/cff2pages.py
@@ -99,12 +99,9 @@ def codemeta_to_apa_citation(codemeta, authors):
     for a in authors:
         family = a.get("family-names", "")
         given = a.get("given-names", "")
+        initial = f"{given[0]}." if given else ""
 
-        initial = ""
-        if given:
-            initial = given[0] + "."
-
-        name = f"{family}, {initial}"
+        name = f"{family} {initial},"
         author_names.append(name)
 
     if len(author_names) == 1:
@@ -116,52 +113,50 @@ def codemeta_to_apa_citation(codemeta, authors):
     elif len(author_names) > 2:
         parts.append(", ".join(author_names[:-1]) + f", & {author_names[-1]}")
 
-    title = codemeta.get("title") or codemeta.get("name")
+    title = codemeta.get("title")
     if title:
         parts.append(title + ".")
 
     version = codemeta.get("version")
     if version:
-        parts.append(f"(Version {version}).")
+        parts.append(f"(version {version}).")
 
-    doi = codemeta.get("doi")
-    if doi:
-        parts.append(f"DOI: {doi}")
-    repo = (
-            codemeta.get("codeRepository")
-            or codemeta.get("repository")
-            or codemeta.get("repository-code")
-    )
+    for identifier in codemeta.get("identifiers", []):
+        if identifier.get("type") == "doi":
+            parts.append(f"DOI: {identifier.get('value')}")
+            break
+    repo = codemeta.get("repository-code")
+
     if repo:
-        repo = repo.replace(".git", "")
         parts.append(f"URL: {repo}")
 
     return " ".join(parts)
 
 def create_metadata_dict(codemeta):
     """
-        parses and creates a dictionary for a codemeta file.
+    parses and creates a dictionary for a codemeta file.
     """
 
-    authors = []
-    identifiers = []
+    identifiers = codemeta.get("identifiers", [])
+    authors = codemeta.get("authors", [])
 
-    doi = codemeta.get("doi")
+    references = []
 
-    if doi:
-        identifiers.append({
-            "type": "doi",
-            "value": doi,
-            "description": "Zenodo DOI of the software"
-        })
+    for ref in codemeta.get("references", []):
+        ref_authors = []
+        for a in ref.get("authors", []):
+            ref_authors.append({
+                "family-names": a.get("family-names"),
+                "given-names": a.get("given-names"),
+                "orcid": a.get("orcid")
+            })
 
-    for a in codemeta.get("author", []):
-        authors.append({
-            "given-names": a.get("givenName"),
-            "family-names": a.get("familyName"),
-            "email": a.get("email"),
-            "affiliation": a.get("affiliation"),
-            "orcid": a.get("id")
+        references.append({
+            "authors": ref_authors,
+            "title": ref.get("title"),
+            "doi": ref.get("doi"),
+            "type": ref.get("type"),
+            "year": ref.get("year")
         })
 
     unique_affiliations = get_unique_affiliations(authors)
@@ -178,7 +173,7 @@ def create_metadata_dict(codemeta):
         "unique_affiliations": unique_affiliations,
         "keywords": codemeta.get("keywords", []),
         "identifiers": identifiers,
-        "references": codemeta.get("references", []),
+        "references": references,
         "citation": {"apa": citation_text}
     }
 

--- a/src/cff2pages/cff2pages.py
+++ b/src/cff2pages/cff2pages.py
@@ -88,6 +88,103 @@ def guess_format(filename, supported_formats):
         raise ValueError(f'Extension of given output file ({filename}) is not one of the supported formats. Formats currently supported: ({supported_formats}).')
 
 
+def codemeta_to_apa_citation(codemeta, authors):
+    """
+    creates citation of a codemeta file for the citation box.
+    """
+
+    parts = []
+    author_names = []
+
+    for a in authors:
+        family = a.get("family-names", "")
+        given = a.get("given-names", "")
+
+        initial = ""
+        if given:
+            initial = given[0] + "."
+
+        name = f"{family}, {initial}"
+        author_names.append(name)
+
+    if len(author_names) == 1:
+        parts.append(author_names[0])
+
+    elif len(author_names) == 2:
+        parts.append(f"{author_names[0]} & {author_names[1]}")
+
+    elif len(author_names) > 2:
+        parts.append(", ".join(author_names[:-1]) + f", & {author_names[-1]}")
+
+    title = codemeta.get("title") or codemeta.get("name")
+    if title:
+        parts.append(title + ".")
+
+    version = codemeta.get("version")
+    if version:
+        parts.append(f"(Version {version}).")
+
+    doi = codemeta.get("doi")
+    if doi:
+        parts.append(f"DOI: {doi}")
+    repo = (
+            codemeta.get("codeRepository")
+            or codemeta.get("repository")
+            or codemeta.get("repository-code")
+    )
+    if repo:
+        repo = repo.replace(".git", "")
+        parts.append(f"URL: {repo}")
+
+    return " ".join(parts)
+
+def create_metadata_dict(codemeta):
+    """
+        parses and creates a dictionary for a codemeta file.
+    """
+
+    authors = []
+    identifiers = []
+
+    doi = codemeta.get("doi")
+
+    if doi:
+        identifiers.append({
+            "type": "doi",
+            "value": doi,
+            "description": "Zenodo DOI of the software"
+        })
+
+    for a in codemeta.get("author", []):
+        authors.append({
+            "given-names": a.get("givenName"),
+            "family-names": a.get("familyName"),
+            "email": a.get("email"),
+            "affiliation": a.get("affiliation"),
+            "orcid": a.get("id")
+        })
+
+    unique_affiliations = get_unique_affiliations(authors)
+    citation_text = codemeta_to_apa_citation(codemeta, authors)
+
+    citation_data = {
+        "title": codemeta.get("title"),
+        "abstract": codemeta.get("abstract"),
+        "version": codemeta.get("version"),
+        "repository": codemeta.get("repository-code"),
+        "license": codemeta.get("license"),
+        "date-released": codemeta.get("datePublished"),
+        "authors": authors,
+        "unique_affiliations": unique_affiliations,
+        "keywords": codemeta.get("keywords", []),
+        "identifiers": identifiers,
+        "references": codemeta.get("references", []),
+        "citation": {"apa": citation_text}
+    }
+
+    return citation_data
+
+
 def main_procedure(cff_path, init_path, show_citation_box=True):
     """
     function to process all steps in the main method
@@ -117,28 +214,11 @@ def main_procedure(cff_path, init_path, show_citation_box=True):
     else:
         cff_file = cff_path
 
-
     if cff_file.endswith('.json'):
         with open(cff_file, 'r', encoding='utf-8') as f:
             codemeta = json.load(f)
 
-        authors = []
-        for a in codemeta.get("author", []):
-            authors.append({
-                "given-names": a.get("givenName"),
-                "family-names": a.get("familyName"),
-                "email": a.get("email")
-            })
-
-        citation_data = {
-            "title": codemeta.get("name"),
-            "description": codemeta.get("description"),
-            "version": codemeta.get("version"),
-            "repository": codemeta.get("codeRepository"),
-            "date-released": codemeta.get("datePublished"),
-            "authors": authors,
-            "citation": {}
-        }
+        citation_data = create_metadata_dict(codemeta)
 
         index_html = template.render(citation_data, show_citation_box=show_citation_box)
 
@@ -171,7 +251,7 @@ def parse_command():
         '-i', '--input', 
         default='./CITATION.cff', 
         nargs='?', 
-        help='path to the input CFF file. Default: ./CITATION.cff'
+        help='path to the input metadata file (CITATION.cff or codemeta.json). Default: ./CITATION.cff'
     )
     parser.add_argument(
         '-o', '--output', 

--- a/src/cff2pages/resources/css/cff2pages.css
+++ b/src/cff2pages/resources/css/cff2pages.css
@@ -24,6 +24,7 @@ body {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
     margin: 20px auto;
     height: fit-content;
+    overflow-wrap: break-word;
     /* Anpassen nach Bedarf */
 }
 

--- a/src/cff2pages/templates/html/base.html
+++ b/src/cff2pages/templates/html/base.html
@@ -31,8 +31,6 @@
         {# cff - abstract #}
         {%- if abstract is defined %}
             <p class="abstract"><b>Abstract</b>: {{ abstract }}</p>
-        {%- elif description is defined %}
-            <p class="abstract"><b>Description</b>: {{ description }}</p>
         {%- endif %}
         {{ reference_block(references) }}
     </div>

--- a/src/cff2pages/templates/html/base.html
+++ b/src/cff2pages/templates/html/base.html
@@ -31,6 +31,8 @@
         {# cff - abstract #}
         {%- if abstract is defined %}
             <p class="abstract"><b>Abstract</b>: {{ abstract }}</p>
+        {%- elif description is defined %}
+            <p class="abstract"><b>Description</b>: {{ description }}</p>
         {%- endif %}
         {{ reference_block(references) }}
     </div>

--- a/src/cff2pages/templates/html/reference_macro.html
+++ b/src/cff2pages/templates/html/reference_macro.html
@@ -47,7 +47,7 @@ Dependencies:
 {% macro reference_block(references) %}
     {%- if references is defined %}
         <div class="references-container">
-            <h2>References</h2>
+            <h2 style="font-weight: bold">References</h2>
             <ul class="references-list">
                 {% for reference in references %}
                     <li class="reference-item">

--- a/tests/expected/expected_current_body.html
+++ b/tests/expected/expected_current_body.html
@@ -43,7 +43,7 @@
             <p class="abstract"><b>Abstract</b>: This is a test abstract.</p>
 
         <div class="references-container">
-            <h2>References</h2>
+            <h2 style="font-weight: bold">References</h2>
             <ul class="references-list">
 
                     <li class="reference-item">

--- a/tests/expected/expected_current_body_no_cb.html
+++ b/tests/expected/expected_current_body_no_cb.html
@@ -46,7 +46,7 @@
             <p class="abstract"><b>Abstract</b>: This is a test abstract.</p>
 
         <div class="references-container">
-            <h2>References</h2>
+            <h2 style="font-weight: bold">References</h2>
             <ul class="references-list">
 
                     <li class="reference-item">

--- a/tests/expected/expected_current_codemeta.md
+++ b/tests/expected/expected_current_codemeta.md
@@ -1,0 +1,42 @@
+# Test codemeta.json
+
+## Author(s)
+- Muster Mina[1]
+- Minster Mana[2]
+- Manster Mona 
+
+1. up
+2. pu
+
+
+
+## Identifiers
+- [repository](https://github.com/organization/site)
+- [SWH - Archive](https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/organization/site)
+- [10.1111/zenodo.111111](https://doi.org/10.1111/zenodo.111111)
+
+
+## Keywords
+- keyword1
+- keyword2
+- keyword3
+- keyword4
+    
+
+
+
+    
+## Cite as (APA):
+Mina M.,, Mana M.,, & Mona M., Test codemeta.json. (version 1.2.3). DOI: 10.1111/zenodo.111111 URL: https://github.com/organization/site
+
+
+
+
+
+## References
+
+
+*  cff2pages: Generate Markup from Your Citation.cff File, Jan Bernoth[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0002-4127-0053){style="margin:3px"}, Toby Hodges[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0003-1766-456X){style="margin:3px"}2025 [10.5281/zenodo.15638585](https://doi.org/10.5281/zenodo.15638585)
+*  cff2pages: Generate a frontend from your metadata, Jan Bernoth[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0002-4127-0053){style="margin:3px"}2024 [10.5281/zenodo.10726204](https://doi.org/10.5281/zenodo.10726204)
+* 💻 Citation File Format, Stephan Druskat[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0003-4925-7248){style="margin:3px"}, Jurriaan H. Spaaks[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0002-7064-4069){style="margin:3px"}, Neil Chue Hong[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0002-8876-7606){style="margin:3px"}, Robert Haines[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0002-9538-7919){style="margin:3px"}, James Baker[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0002-2682-6922){style="margin:3px"}, Spencer Bliven[![Author ORCID](./assets/img/orcid_16x16.webp)](None){style="margin:3px"}, Egon Willighagen[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0001-7542-0286){style="margin:3px"}, David Pérez-Suárez[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0003-0784-6909){style="margin:3px"}, Olexandr Konovalov[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0001-5299-3292){style="margin:3px"} [10.5281/zenodo.1003149](https://doi.org/10.5281/zenodo.1003149)
+* 📖 Ya2RO: A tool for creating Research Object from minimum metadata, Antonia Pavel[![Author ORCID](./assets/img/orcid_16x16.webp)](None){style="margin:3px"}, Daniel Garijo[![Author ORCID](./assets/img/orcid_16x16.webp)](https://orcid.org/0000-0003-0454-7145){style="margin:3px"}2023 [10.4126/FRL01-006444984](https://doi.org/10.4126/FRL01-006444984)

--- a/tests/expected/expected_current_codemeta_body.html
+++ b/tests/expected/expected_current_codemeta_body.html
@@ -1,0 +1,95 @@
+<body>
+
+<div class="container">
+    <div class="content">
+        <h1 class="blog-title"> Test CodeMeta</h1>
+    <h2>
+            Muster Mina<sup>1</sup>,
+            Minster Mana<sup>2</sup>,
+            Manster Mona
+    </h2>
+    <ul>
+        <sup>1</sup> : up
+        <sup>2</sup> : pu
+        </ul>
+        <div class="keyword-container">
+            <b>Keywords:</b>
+            <ul class="keyword-list">
+                <li class="keyword-item">
+                    <a class="keyword">keyword1</a>
+                </li>
+                <li class="keyword-item">
+                    <a class="keyword">keyword2</a>
+                </li>
+                <li class="keyword-item">
+                    <a class="keyword">keyword3</a>
+                </li>
+                <li class="keyword-item">
+                    <a class="keyword">keyword4</a>
+                </li>
+            </ul>
+        </div>
+        <div class="badges">
+            <a class="badge-item" href="https://github.com/organization/codemeta-site" target="_blank">
+                <img src="./assets/img/github-logo.png" alt="Github Logo">
+            </a>
+            <a href="https://github.com/organization/codemeta-site" target="_blank">Repository</a>
+
+            <a href="https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/organization/codemeta-site">
+                <img src="https://archive.softwareheritage.org/badge/origin/https://github.com/organization/codemeta-site"
+                     alt="Archived | https://github.com/organization/codemeta-site"/>
+            </a>
+
+            <a href="https://doi.org/10.2222/zenodo.222222">
+                <img src="https://img.shields.io/badge/DOI_-10.2222/zenodo.222222-blue"
+                     alt="DOI"/>
+            </a>
+        </div>
+
+        <p class="licence"><b>License</b>: MIT</p>
+
+        <p class="abstract"><b>Abstract</b>: This is a codemeta test abstract.</p>
+
+        <div class="references-container">
+            <h2>References</h2>
+            <ul class="references-list">
+
+                <li class="reference-item">
+                    <span class="reference-icon" title="type software">
+                        💻
+                    </span>
+                    <span class="reference-title">Example Software Reference</span>,
+                    <span class="reference-author">
+                        John Doe
+                    </span>,
+                    <span class="year">2024</span>,
+                    <span class="reference-doi">
+                        <a href="https://doi.org/10.0000/example" target="_blank">10.0000/example</a>
+                    </span>
+                </li>
+
+            </ul>
+        </div>
+
+    </div>
+
+    <div class="citation">
+        <p><b>cite as (APA):</b></p>
+        <p id="citationText">
+Mina M., Mana M., Mona M. Test CodeMeta (version 1.0.0). DOI: 10.2222/zenodo.222222 URL: https://github.com/organization/codemeta-site
+        </p>
+        <button id="copyButton">copy citation</button>
+        <div id="notification" class="notification">Copied!</div>
+    </div>
+
+</div>
+
+<div class="footer-container">
+    <footer class="footer">
+        <p>Generated with <a href="https://github.com/University-of-Potsdam-MM/cff2pages"
+                             target="_blank">cff2pages</a>.
+        </p>
+    </footer>
+</div>
+
+</body>

--- a/tests/expected/expected_current_codemeta_body.html
+++ b/tests/expected/expected_current_codemeta_body.html
@@ -2,7 +2,10 @@
 
 <div class="container">
     <div class="content">
-        <h1 class="blog-title"> Test CodeMeta</h1>
+
+        <h1 class="blog-title"> Test codemeta.json</h1>
+
+
     <h2>
             Muster Mina<sup>1</sup>,
             Minster Mana<sup>2</sup>,
@@ -12,77 +15,184 @@
         <sup>1</sup> : up
         <sup>2</sup> : pu
         </ul>
+
         <div class="keyword-container">
             <b>Keywords:</b>
-            <ul class="keyword-list">
-                <li class="keyword-item">
-                    <a class="keyword">keyword1</a>
-                </li>
-                <li class="keyword-item">
-                    <a class="keyword">keyword2</a>
-                </li>
-                <li class="keyword-item">
-                    <a class="keyword">keyword3</a>
-                </li>
-                <li class="keyword-item">
-                    <a class="keyword">keyword4</a>
-                </li>
+            <ul class="keyword-list"><li class="keyword-item">
+                        <a class="keyword">keyword1</a>
+                    </li><li class="keyword-item">
+                        <a class="keyword">keyword2</a>
+                    </li><li class="keyword-item">
+                        <a class="keyword">keyword3</a>
+                    </li><li class="keyword-item">
+                        <a class="keyword">keyword4</a>
+                    </li>
             </ul>
         </div>
-        <div class="badges">
-            <a class="badge-item" href="https://github.com/organization/codemeta-site" target="_blank">
-                <img src="./assets/img/github-logo.png" alt="Github Logo">
-            </a>
-            <a href="https://github.com/organization/codemeta-site" target="_blank">Repository</a>
 
-            <a href="https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/organization/codemeta-site">
-                <img src="https://archive.softwareheritage.org/badge/origin/https://github.com/organization/codemeta-site"
-                     alt="Archived | https://github.com/organization/codemeta-site"/>
-            </a>
 
-            <a href="https://doi.org/10.2222/zenodo.222222">
-                <img src="https://img.shields.io/badge/DOI_-10.2222/zenodo.222222-blue"
-                     alt="DOI"/>
-            </a>
+
+        <div class="badges"><a class="badge-item" href="https://github.com/organization/site" target="_blank">
+                        <img src="./assets/img/github-logo.png" alt="Github Logo"></a>
+                <a href="https://github.com/organization/site" target="_blank">Repository</a>
+                        <a href="https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/organization/site">
+                            <img src="https://archive.softwareheritage.org/badge/origin/https://github.com/organization/site"
+                                 alt="Archived | https://github.com/organization/site"/>
+                        </a>
+
+                    <a href="https://doi.org/10.1111/zenodo.111111">
+                        <img src="https://img.shields.io/badge/DOI_-10.1111/zenodo.111111-blue"
+                             alt="DOI"/>
+                    </a>
         </div>
 
-        <p class="licence"><b>License</b>: MIT</p>
 
-        <p class="abstract"><b>Abstract</b>: This is a codemeta test abstract.</p>
+
+            <p class="licence"><b>License</b>: MIT</p>
+
+            <p class="abstract"><b>Abstract</b>: This is a test abstract.</p>
 
         <div class="references-container">
-            <h2>References</h2>
+            <h2 style="font-weight: bold">References</h2>
             <ul class="references-list">
 
-                <li class="reference-item">
-                    <span class="reference-icon" title="type software">
-                        💻
-                    </span>
-                    <span class="reference-title">Example Software Reference</span>,
-                    <span class="reference-author">
-                        John Doe
-                    </span>,
-                    <span class="year">2024</span>,
-                    <span class="reference-doi">
-                        <a href="https://doi.org/10.0000/example" target="_blank">10.0000/example</a>
-                    </span>
-                </li>
+                    <li class="reference-item">
+                        <span class="reference-icon" title="type conference-paper">
+                            <i>type: conference-paper  </i>
+                        </span>
+                        <span class="reference-title">cff2pages: Generate Markup from Your Citation.cff File</span>,
+                        <span class="reference-author">
+                        Jan Bernoth<a href="https://orcid.org/0000-0002-4127-0053"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        Toby Hodges<a href="https://orcid.org/0000-0003-1766-456X"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>
+                        </span>
+                        , <span class="year">2025</span>,
+
+                        <span class="reference-doi"><a href="https://doi.org/10.5281/zenodo.15638585"
+                                                       target="_blank">10.5281/zenodo.15638585</a></span>
+                    </li>
+
+                    <li class="reference-item">
+                        <span class="reference-icon" title="type conference-paper">
+                            <i>type: conference-paper  </i>
+                        </span>
+                        <span class="reference-title">cff2pages: Generate a frontend from your metadata</span>,
+                        <span class="reference-author">
+                        Jan Bernoth<a href="https://orcid.org/0000-0002-4127-0053"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>
+                        </span>
+                        , <span class="year">2024</span>,
+
+                        <span class="reference-doi"><a href="https://doi.org/10.5281/zenodo.10726204"
+                                                       target="_blank">10.5281/zenodo.10726204</a></span>
+                    </li>
+
+                    <li class="reference-item">
+                        <span class="reference-icon" title="type software">
+                            💻
+
+                        </span>
+                        <span class="reference-title">Citation File Format</span>,
+                        <span class="reference-author">
+                        Stephan Druskat<a href="https://orcid.org/0000-0003-4925-7248"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        Jurriaan H. Spaaks<a href="https://orcid.org/0000-0002-7064-4069"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        Neil Chue Hong<a href="https://orcid.org/0000-0002-8876-7606"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        Robert Haines<a href="https://orcid.org/0000-0002-9538-7919"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        James Baker<a href="https://orcid.org/0000-0002-2682-6922"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        Spencer Bliven<a href="None"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        Egon Willighagen<a href="https://orcid.org/0000-0001-7542-0286"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        David Pérez-Suárez<a href="https://orcid.org/0000-0003-0784-6909"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        Olexandr Konovalov<a href="https://orcid.org/0000-0001-5299-3292"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>
+                        </span>
+
+                        <span class="reference-doi"><a href="https://doi.org/10.5281/zenodo.1003149"
+                                                       target="_blank">10.5281/zenodo.1003149</a></span>
+                    </li>
+
+                    <li class="reference-item">
+                        <span class="reference-icon" title="type article">
+                            📖
+
+                        </span>
+                        <span class="reference-title">Ya2RO: A tool for creating Research Object from minimum metadata</span>,
+                        <span class="reference-author">
+                        Antonia Pavel<a href="None"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>,
+                        Daniel Garijo<a href="https://orcid.org/0000-0003-0454-7145"><img decoding="async" alt=""
+                                                              src="./assets/img/orcid_16x16.webp"
+                                                              style="width:16px; height:16px; margin:3px"/></a>
+                        </span>
+                        , <span class="year">2023</span>,
+
+                        <span class="reference-doi"><a href="https://doi.org/10.4126/FRL01-006444984"
+                                                       target="_blank">10.4126/FRL01-006444984</a></span>
+                    </li>
 
             </ul>
         </div>
 
     </div>
 
-    <div class="citation">
-        <p><b>cite as (APA):</b></p>
-        <p id="citationText">
-Mina M., Mana M., Mona M. Test CodeMeta (version 1.0.0). DOI: 10.2222/zenodo.222222 URL: https://github.com/organization/codemeta-site
-        </p>
-        <button id="copyButton">copy citation</button>
-        <div id="notification" class="notification">Copied!</div>
-    </div>
+
+
+        <div class="citation">
+            <p><b>cite as (APA):</b></p>
+            <p id="citationText">Mina M.,, Mana M.,, &amp; Mona M., Test codemeta.json. (version 1.2.3). DOI: 10.1111/zenodo.111111 URL: https://github.com/organization/site</p>
+            <button id="copyButton">copy citation</button>
+            <div id="notification" class="notification">Copied!</div>
+        </div>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const copyButton = document.getElementById('copyButton');
+                if (copyButton) {
+                    copyButton.addEventListener('click', function () {
+                        const citationText = document.getElementById('citationText').innerText;
+                        navigator.clipboard.writeText(citationText)
+                            .then(() => {
+                                // Zeige die Benachrichtigung
+                                const notification = document.getElementById('notification');
+                                notification.style.opacity = '1';
+
+                                // Verstecke die Benachrichtigung nach 3 Sekunden
+                                setTimeout(() => {
+                                    notification.style.opacity = '0';
+                                }, 3000);
+                            })
+                            .catch(err => {
+                                console.error('Errors in the copy process: ', err);
+                            });
+                    });
+                }
+            });
+        </script>
+
+
 
 </div>
+
 
 <div class="footer-container">
     <footer class="footer">

--- a/tests/fixtures/current_codemeta.json
+++ b/tests/fixtures/current_codemeta.json
@@ -1,0 +1,148 @@
+{
+  "cff-version": "1.2.0",
+  "type": "Software",
+  "title": "Test codemeta.json",
+  "version": "1.2.3",
+  "abstract": "This is a test abstract.",
+  "license": "MIT",
+  "repository-code": "https://github.com/organization/site",
+  "keywords": [
+    "keyword1",
+    "keyword2",
+    "keyword3",
+    "keyword4"
+  ],
+  "authors": [
+    {
+      "given-names": "Muster",
+      "family-names": "Mina",
+      "affiliation": "up"
+    },
+    {
+      "given-names": "Minster",
+      "family-names": "Mana",
+      "affiliation": "pu"
+    },
+    {
+      "given-names": "Manster",
+      "family-names": "Mona"
+    }
+  ],
+  "identifiers": [
+    {
+      "type": "swh",
+      "value": "swh:1:dir:1e3e28077c43ca999f434f29b6a872f5581b48e2",
+      "description": "The archive of this project in Software Heritage. All persistent versions are accessible via this directory"
+    },
+    {
+      "type": "doi",
+      "value": "10.1111/zenodo.111111",
+      "description": "Zenodo DOI"
+    }
+  ],
+  "references": [
+    {
+      "type": "conference-paper",
+      "title": "cff2pages: Generate Markup from Your Citation.cff File",
+      "doi": "10.5281/zenodo.15638585",
+      "year": "2025",
+      "authors": [
+        {
+          "given-names": "Jan",
+          "family-names": "Bernoth",
+          "orcid": "https://orcid.org/0000-0002-4127-0053"
+        },
+        {
+          "given-names": "Toby",
+          "family-names": "Hodges",
+          "orcid": "https://orcid.org/0000-0003-1766-456X"
+        }
+      ]
+    },
+    {
+      "type": "conference-paper",
+      "title": "cff2pages: Generate a frontend from your metadata",
+      "doi": "10.5281/zenodo.10726204",
+      "year": "2024",
+      "authors": [
+        {
+          "given-names": "Jan",
+          "family-names": "Bernoth",
+          "orcid": "https://orcid.org/0000-0002-4127-0053"
+        }
+      ]
+    },
+    {
+      "type": "software",
+      "title": "Citation File Format",
+      "version": "1.2.0",
+      "doi": "10.5281/zenodo.1003149",
+      "authors": [
+        {
+          "family-names": "Druskat",
+          "given-names": "Stephan",
+          "orcid": "https://orcid.org/0000-0003-4925-7248"
+        },
+        {
+          "family-names": "Spaaks",
+          "given-names": "Jurriaan H.",
+          "orcid": "https://orcid.org/0000-0002-7064-4069"
+        },
+        {
+          "family-names": "Chue Hong",
+          "given-names": "Neil",
+          "orcid": "https://orcid.org/0000-0002-8876-7606"
+        },
+        {
+          "family-names": "Haines",
+          "given-names": "Robert",
+          "orcid": "https://orcid.org/0000-0002-9538-7919"
+        },
+        {
+          "family-names": "Baker",
+          "given-names": "James",
+          "orcid": "https://orcid.org/0000-0002-2682-6922"
+        },
+        {
+          "family-names": "Bliven",
+          "given-names": "Spencer",
+          "orcid: https": "//orcid.org/0000-0002-1200-1698",
+          "email": "spencer.bliven@gmail.com"
+        },
+        {
+          "family-names": "Willighagen",
+          "given-names": "Egon",
+          "orcid": "https://orcid.org/0000-0001-7542-0286"
+        },
+        {
+          "family-names": "Pérez-Suárez",
+          "given-names": "David",
+          "orcid": "https://orcid.org/0000-0003-0784-6909",
+          "website": "https://dpshelio.github.io"
+        },
+        {
+          "family-names": "Konovalov",
+          "given-names": "Olexandr",
+          "orcid": "https://orcid.org/0000-0001-5299-3292"
+        }
+      ]
+    },
+    {
+      "type": "article",
+      "title": "Ya2RO: A tool for creating Research Object from minimum metadata",
+      "doi": "10.4126/FRL01-006444984",
+      "year": "2023",
+      "authors": [
+        {
+          "given-names": "Antonia",
+          "family-names": "Pavel"
+        },
+        {
+          "given-names": "Daniel",
+          "family-names": "Garijo",
+          "orcid": "https://orcid.org/0000-0003-0454-7145"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_cff2pages.py
+++ b/tests/test_cff2pages.py
@@ -157,11 +157,13 @@ class CffToHtmlTester(unittest.TestCase):
         Iterate over all .cff files in the fixtures directory, convert them to HTML,
         and compare the generated output with the expected HTML files.
         """
-        fixtures_path = os.path.join(os.path.dirname(__file__), FIXTURES_DIR, "*.cff")
+        fixtures_path = os.path.join(os.path.dirname(__file__), FIXTURES_DIR, "*.")
         cff_files = glob.glob(fixtures_path)
 
         for cff_file in cff_files:
             file_name = os.path.basename(cff_file)
+            if not (file_name.endswith(".cff") or file_name.endswith(".json")):
+                continue
             tmp_dir = self.temp_dir.name
             shutil.copy2(cff_file, tmp_dir)
             input_path = os.path.join(tmp_dir, file_name)
@@ -169,9 +171,9 @@ class CffToHtmlTester(unittest.TestCase):
             # Subtest for HTML conversion
             with self.subTest(f'file: {file_name}, format: html', cff_file=cff_file):
                 print(f'file: {file_name}, format: html')
+                base_name = file_name.replace(".cff", "").replace(".json", "")
                 expected_file = os.path.join(os.path.dirname(__file__), EXPECTED_DIR,
-                                             f"expected_{file_name.replace('.cff', '_body.html')}")
-
+                                            f"expected_{base_name}_body.html")
                 if not os.path.exists(expected_file):
                     self.fail(f"Expected file missing: {expected_file}")
                 output_path = os.path.join(tmp_dir, "public", "cff2pages.html")

--- a/tests/test_cff2pages.py
+++ b/tests/test_cff2pages.py
@@ -154,16 +154,16 @@ class CffToHtmlTester(unittest.TestCase):
 
     def test_cff_files(self):
         """
-        Iterate over all .cff files in the fixtures directory, convert them to HTML,
+        Iterate over all .cff in the fixtures directory, convert them to HTML,
         and compare the generated output with the expected HTML files.
         """
-        fixtures_path = os.path.join(os.path.dirname(__file__), FIXTURES_DIR, "*.")
+        fixtures_path = os.path.join(os.path.dirname(__file__), FIXTURES_DIR, "*.cff")
         cff_files = glob.glob(fixtures_path)
 
         for cff_file in cff_files:
             file_name = os.path.basename(cff_file)
-            if not (file_name.endswith(".cff") or file_name.endswith(".json")):
-                continue
+            #if not (file_name.endswith(".cff") or file_name.endswith(".json")):
+                #continue
             tmp_dir = self.temp_dir.name
             shutil.copy2(cff_file, tmp_dir)
             input_path = os.path.join(tmp_dir, file_name)
@@ -171,9 +171,8 @@ class CffToHtmlTester(unittest.TestCase):
             # Subtest for HTML conversion
             with self.subTest(f'file: {file_name}, format: html', cff_file=cff_file):
                 print(f'file: {file_name}, format: html')
-                base_name = file_name.replace(".cff", "").replace(".json", "")
                 expected_file = os.path.join(os.path.dirname(__file__), EXPECTED_DIR,
-                                            f"expected_{base_name}_body.html")
+                                             f"expected_{file_name.replace('.cff', '_body.html')}")
                 if not os.path.exists(expected_file):
                     self.fail(f"Expected file missing: {expected_file}")
                 output_path = os.path.join(tmp_dir, "public", "cff2pages.html")
@@ -259,6 +258,77 @@ class CffToHtmlTester(unittest.TestCase):
 
                     self.assertEqual(actual_html, expected_html)
 
+    def test_codemeta_files(self):
+        """
+        Iterate over all .json CodeMeta files in the fixtures directory,
+        convert them to HTML and Markdown, and compare with expected outputs.
+        """
+        fixtures_path = os.path.join(os.path.dirname(__file__), FIXTURES_DIR, "*.json")
+        json_files = glob.glob(fixtures_path)
+
+        for json_file in json_files:
+            file_name = os.path.basename(json_file)
+            tmp_dir = self.temp_dir.name
+            shutil.copy2(json_file, tmp_dir)
+            input_path = os.path.join(tmp_dir, file_name)
+
+            base_name = file_name.replace(".json", "")
+
+            # HTML test
+            with self.subTest(f'file: {file_name}, format: html'):
+                print(f'file: {file_name}, format: html')
+
+                expected_file = os.path.join(
+                    os.path.dirname(__file__),
+                    EXPECTED_DIR,
+                    f"expected_{base_name}_body.html"
+                )
+
+                if not os.path.exists(expected_file):
+                    self.fail(f"Expected file missing: {expected_file}")
+
+                output_path = os.path.join(tmp_dir, "public", "cff2pages.html")
+
+                main_procedure(input_path, output_path)
+                index_file = check_folders(self, tmp_dir, "html")
+
+                actual_body = read_div_from_body(index_file, div_class="container")
+                expected_body = read_div_from_body(expected_file, div_class="container")
+
+                actual_body_cleaned = remove_script_tags(actual_body)
+                expected_body_cleaned = remove_script_tags(expected_body)
+
+                try:
+                    assert actual_body_cleaned.prettify() == expected_body_cleaned.prettify()
+                except AssertionError as e:
+                    self._save_failed_html(output_path, file_name + "_failed_output.html")
+                    raise e
+
+            # Markdown test
+            with self.subTest(f'file: {file_name}, format: md'):
+                print(f'file: {file_name}, format: md')
+
+                expected_file = os.path.join(
+                    os.path.dirname(__file__),
+                    EXPECTED_DIR,
+                    f"expected_{base_name}.md"
+                )
+
+                if not os.path.exists(expected_file):
+                    self.fail(f"Expected file missing: {expected_file}")
+
+                output_path = os.path.join(tmp_dir, "public", "cff2pages.md")
+
+                main_procedure(input_path, output_path)
+                index_file = check_folders(self, tmp_dir, "md")
+
+                with open(index_file, encoding="utf-8") as f:
+                    actual_html = markdown.markdown(f.read())
+
+                with open(expected_file, encoding="utf-8") as f:
+                    expected_html = markdown.markdown(f.read())
+
+                self.assertEqual(actual_html, expected_html)
 
 
 class CffTomlComparer(unittest.TestCase):

--- a/tests/test_cff2pages.py
+++ b/tests/test_cff2pages.py
@@ -162,8 +162,6 @@ class CffToHtmlTester(unittest.TestCase):
 
         for cff_file in cff_files:
             file_name = os.path.basename(cff_file)
-            #if not (file_name.endswith(".cff") or file_name.endswith(".json")):
-                #continue
             tmp_dir = self.temp_dir.name
             shutil.copy2(cff_file, tmp_dir)
             input_path = os.path.join(tmp_dir, file_name)


### PR DESCRIPTION
This merge request extends `cff2pages` to support metadata provided in `codemeta.json` files

## Changes

- Added support for parsing `codemeta.json` metadata files
- README Updated to document CodeMeta support
- Added 1 new test scenario for CodeMeta parsing